### PR TITLE
Implement user-specific categories

### DIFF
--- a/src/api/api/Controllers/CategoryController.cs
+++ b/src/api/api/Controllers/CategoryController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Linq;
 using FinSync.Data;
 using FinSync.DTOs;
 using FinSync.Models;
@@ -20,10 +21,13 @@ namespace FinSync.Controllers
         }
 
         [HttpGet]
-        [AllowAnonymous]
         public async Task<ActionResult<IEnumerable<CategoryDto>>> GetCategories()
         {
+            var userId = GetUserId();
+            if (userId == null) return Unauthorized("Invalid token.");
+
             var categories = await _context.Categories
+                .Where(c => c.UserId == userId.Value)
                 .OrderBy(c => c.CategoryName)
                 .Select(c => new CategoryDto
                 {
@@ -37,13 +41,16 @@ namespace FinSync.Controllers
         [HttpPost]
         public async Task<IActionResult> CreateCategory([FromBody] CategoryDto dto)
         {
+            var userId = GetUserId();
+            if (userId == null) return Unauthorized("Invalid token.");
+
             if (string.IsNullOrWhiteSpace(dto.CategoryName))
                 return BadRequest("Category name required.");
 
-            if (await _context.Categories.AnyAsync(c => c.CategoryName == dto.CategoryName))
+            if (await _context.Categories.AnyAsync(c => c.UserId == userId.Value && c.CategoryName == dto.CategoryName))
                 return Conflict("Category already exists.");
 
-            var category = new Category { CategoryName = dto.CategoryName };
+            var category = new Category { CategoryName = dto.CategoryName, UserId = userId.Value };
             _context.Categories.Add(category);
             await _context.SaveChangesAsync();
             dto.CategoryId = category.CategoryId;
@@ -53,7 +60,10 @@ namespace FinSync.Controllers
         [HttpPut("{id}")]
         public async Task<IActionResult> UpdateCategory(int id, [FromBody] CategoryDto dto)
         {
-            var cat = await _context.Categories.FindAsync(id);
+            var userId = GetUserId();
+            if (userId == null) return Unauthorized("Invalid token.");
+
+            var cat = await _context.Categories.FirstOrDefaultAsync(c => c.CategoryId == id && c.UserId == userId.Value);
             if (cat == null) return NotFound();
 
             if (string.IsNullOrWhiteSpace(dto.CategoryName))
@@ -67,12 +77,21 @@ namespace FinSync.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> DeleteCategory(int id)
         {
-            var cat = await _context.Categories.FindAsync(id);
+            var userId = GetUserId();
+            if (userId == null) return Unauthorized("Invalid token.");
+
+            var cat = await _context.Categories.FirstOrDefaultAsync(c => c.CategoryId == id && c.UserId == userId.Value);
             if (cat == null) return NotFound();
 
             _context.Categories.Remove(cat);
             await _context.SaveChangesAsync();
             return Ok(new { message = "Category removed." });
+        }
+
+        private int? GetUserId()
+        {
+            var claim = User.FindFirst("userId")?.Value;
+            return int.TryParse(claim, out var id) ? id : null;
         }
     }
 }

--- a/src/api/api/Models/Category.cs
+++ b/src/api/api/Models/Category.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace FinSync.Models
 {
@@ -7,7 +8,12 @@ namespace FinSync.Models
     {
         [Key]
         public int CategoryId { get; set; }
+
+        public int UserId { get; set; }
         public string CategoryName { get; set; }
+
+        [ForeignKey(nameof(UserId))]
+        public User User { get; set; }
 
         public ICollection<Expense> Expenses { get; set; }
         public ICollection<Budget> Budgets { get; set; }

--- a/src/api/api/Models/FinSyncContext.cs
+++ b/src/api/api/Models/FinSyncContext.cs
@@ -28,20 +28,14 @@ namespace FinSync.Data
                 .IsUnique();
 
             modelBuilder.Entity<Category>()
-                .HasIndex(c => c.CategoryName)
+                .HasIndex(c => new { c.UserId, c.CategoryName })
                 .IsUnique();
 
-            modelBuilder.Entity<Category>().HasData(
-                new Category { CategoryId = 1, CategoryName = "Alimentação" },
-                new Category { CategoryId = 2, CategoryName = "Transporte" },
-                new Category { CategoryId = 3, CategoryName = "Habitação" },
-                new Category { CategoryId = 4, CategoryName = "Educação" },
-                new Category { CategoryId = 5, CategoryName = "Lazer"},
-                new Category { CategoryId = 6, CategoryName = "Salário" },
-                new Category { CategoryId = 7, CategoryName = "Investimentos" },
-                new Category { CategoryId = 8, CategoryName = "Presentes" },
-                new Category { CategoryId = 9, CategoryName = "Outros" }
-            );
+            modelBuilder.Entity<Category>()
+                .HasOne(c => c.User)
+                .WithMany()
+                .HasForeignKey(c => c.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
 
             modelBuilder.Entity<Income>()
                 .HasIndex(i => new { i.RecurringScheduleId, i.Date })


### PR DESCRIPTION
## Summary
- make `Category` belong to a `User`
- remove global seeding and enforce unique per-user categories
- restrict `CategoryController` actions to the authenticated user's data
- fix compile error by importing `System.Linq`

## Testing
- `dotnet build src/api/api -c Release`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68514ab65018832eae84fa818bbabbe3