### PR TITLE
Configure category-user FK restrict delete

### DIFF
--- a/src/api/api/Migrations/20250617210449_AddCategoryUserRelation.Designer.cs
+++ b/src/api/api/Migrations/20250617210449_AddCategoryUserRelation.Designer.cs
@@ -4,6 +4,7 @@ using FinSync.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FinSync.Migrations
 {
     [DbContext(typeof(FinSyncContext))]
-    partial class FinSyncContextModelSnapshot : ModelSnapshot
+    [Migration("20250617210449_AddCategoryUserRelation")]
+    partial class AddCategoryUserRelation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -275,7 +278,7 @@ namespace FinSync.Migrations
                     b.HasOne("FinSync.Models.Category", "Category")
                         .WithMany("Budgets")
                         .HasForeignKey("CategoryId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("FinSync.Models.User", "User")
@@ -305,7 +308,7 @@ namespace FinSync.Migrations
                     b.HasOne("FinSync.Models.Category", "Category")
                         .WithMany("Expenses")
                         .HasForeignKey("CategoryId")
-                        .OnDelete(DeleteBehavior.Restrict)
+                        .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
 
                     b.HasOne("FinSync.Models.User", "User")

--- a/src/api/api/Migrations/20250617210449_AddCategoryUserRelation.cs
+++ b/src/api/api/Migrations/20250617210449_AddCategoryUserRelation.cs
@@ -1,0 +1,124 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace FinSync.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCategoryUserRelation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_Categories_CategoryName",
+                table: "Categories");
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 6);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 7);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 8);
+
+            migrationBuilder.DeleteData(
+                table: "Categories",
+                keyColumn: "CategoryId",
+                keyValue: 9);
+
+            migrationBuilder.AddColumn<int>(
+                name: "UserId",
+                table: "Categories",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Categories_UserId_CategoryName",
+                table: "Categories",
+                columns: new[] { "UserId", "CategoryName" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Categories_Users_UserId",
+                table: "Categories",
+                column: "UserId",
+                principalTable: "Users",
+                principalColumn: "UserId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Categories_Users_UserId",
+                table: "Categories");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Categories_UserId_CategoryName",
+                table: "Categories");
+
+            migrationBuilder.DropColumn(
+                name: "UserId",
+                table: "Categories");
+
+            migrationBuilder.InsertData(
+                table: "Categories",
+                columns: new[] { "CategoryId", "CategoryName" },
+                values: new object[,]
+                {
+                    { 1, "Alimentação" },
+                    { 2, "Transporte" },
+                    { 3, "Habitação" },
+                    { 4, "Educação" },
+                    { 5, "Lazer" },
+                    { 6, "Salário" },
+                    { 7, "Investimentos" },
+                    { 8, "Presentes" },
+                    { 9, "Outros" }
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Categories_CategoryName",
+                table: "Categories",
+                column: "CategoryName",
+                unique: true);
+        }
+    }
+}

--- a/src/api/api/Migrations/20250617221523_RestrictCategoryCascade.Designer.cs
+++ b/src/api/api/Migrations/20250617221523_RestrictCategoryCascade.Designer.cs
@@ -4,6 +4,7 @@ using FinSync.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FinSync.Migrations
 {
     [DbContext(typeof(FinSyncContext))]
-    partial class FinSyncContextModelSnapshot : ModelSnapshot
+    [Migration("20250617221523_RestrictCategoryCascade")]
+    partial class RestrictCategoryCascade
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/api/Migrations/20250617221523_RestrictCategoryCascade.cs
+++ b/src/api/api/Migrations/20250617221523_RestrictCategoryCascade.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinSync.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestrictCategoryCascade : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Budgets_Categories_CategoryId",
+                table: "Budgets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Expenses_Categories_CategoryId",
+                table: "Expenses");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Budgets_Categories_CategoryId",
+                table: "Budgets",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "CategoryId",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Expenses_Categories_CategoryId",
+                table: "Expenses",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "CategoryId",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Budgets_Categories_CategoryId",
+                table: "Budgets");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Expenses_Categories_CategoryId",
+                table: "Expenses");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Budgets_Categories_CategoryId",
+                table: "Budgets",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "CategoryId",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Expenses_Categories_CategoryId",
+                table: "Expenses",
+                column: "CategoryId",
+                principalTable: "Categories",
+                principalColumn: "CategoryId",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/api/api/Models/FinSyncContext.cs
+++ b/src/api/api/Models/FinSyncContext.cs
@@ -35,7 +35,7 @@ namespace FinSync.Data
                 .HasOne(c => c.User)
                 .WithMany()
                 .HasForeignKey(c => c.UserId)
-                .OnDelete(DeleteBehavior.Cascade);
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Income>()
                 .HasIndex(i => new { i.RecurringScheduleId, i.Date })
@@ -46,13 +46,25 @@ namespace FinSync.Data
                 .Property(i => i.Amount)
                 .HasColumnType("decimal(18, 2)");
 
-                        modelBuilder.Entity<Expense>()
+            modelBuilder.Entity<Expense>()
                 .Property(e => e.Amount)
                 .HasColumnType("decimal(18, 2)");
+
+            modelBuilder.Entity<Expense>()
+                .HasOne(e => e.Category)
+                .WithMany(c => c.Expenses)
+                .HasForeignKey(e => e.CategoryId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Budget>()
                 .Property(b => b.MonthlyLimit)
                 .HasColumnType("decimal(18, 2)");
+
+            modelBuilder.Entity<Budget>()
+                .HasOne(b => b.Category)
+                .WithMany(c => c.Budgets)
+                .HasForeignKey(b => b.CategoryId)
+                .OnDelete(DeleteBehavior.Restrict);
 
             modelBuilder.Entity<Goal>()
                 .Property(g => g.TargetAmount)


### PR DESCRIPTION
## Summary
- enforce DeleteBehavior.Restrict on `Category` → `User`
- prevent cascading deletes from `Category` to `Budget`/`Expense`
- add EF migration to update cascade rules

## Testing
- `dotnet ef migrations add RestrictCategoryCascade`
- `dotnet ef database update` *(fails: server not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d7e3ff30832e8cbfd34c91839d82