### PR TITLE
Add color field to categories

### DIFF
--- a/src/api/api/Controllers/CategoryController.cs
+++ b/src/api/api/Controllers/CategoryController.cs
@@ -32,7 +32,8 @@ namespace FinSync.Controllers
                 .Select(c => new CategoryDto
                 {
                     CategoryId = c.CategoryId,
-                    CategoryName = c.CategoryName
+                    CategoryName = c.CategoryName,
+                    Color = c.Color
                 })
                 .ToListAsync();
             return Ok(categories);
@@ -53,7 +54,8 @@ namespace FinSync.Controllers
                 .Select(c => new CategoryDto
                 {
                     CategoryId = c.CategoryId,
-                    CategoryName = c.CategoryName
+                    CategoryName = c.CategoryName,
+                    Color = c.Color
                 })
                 .ToListAsync();
 
@@ -68,11 +70,13 @@ namespace FinSync.Controllers
 
             if (string.IsNullOrWhiteSpace(dto.CategoryName))
                 return BadRequest("Category name required.");
+            if (string.IsNullOrWhiteSpace(dto.Color))
+                return BadRequest("Color required.");
 
             if (await _context.Categories.AnyAsync(c => c.UserId == userId.Value && c.CategoryName == dto.CategoryName))
                 return Conflict("Category already exists.");
 
-            var category = new Category { CategoryName = dto.CategoryName, UserId = userId.Value };
+            var category = new Category { CategoryName = dto.CategoryName, UserId = userId.Value, Color = dto.Color };
             _context.Categories.Add(category);
             await _context.SaveChangesAsync();
             dto.CategoryId = category.CategoryId;
@@ -92,6 +96,7 @@ namespace FinSync.Controllers
                 return BadRequest("Category name required.");
 
             cat.CategoryName = dto.CategoryName;
+            cat.Color = dto.Color;
             await _context.SaveChangesAsync();
             return Ok(new { message = "Category updated." });
         }

--- a/src/api/api/DTOs/CategoryDto.cs
+++ b/src/api/api/DTOs/CategoryDto.cs
@@ -4,4 +4,5 @@ public class CategoryDto
 {
     public int CategoryId { get; set; }
     public string CategoryName { get; set; }
+    public string Color { get; set; }
 }

--- a/src/api/api/Migrations/20250621153357_AddCategoryColor.Designer.cs
+++ b/src/api/api/Migrations/20250621153357_AddCategoryColor.Designer.cs
@@ -4,6 +4,7 @@ using FinSync.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace FinSync.Migrations
 {
     [DbContext(typeof(FinSyncContext))]
-    partial class FinSyncContextModelSnapshot : ModelSnapshot
+    [Migration("20250621153357_AddCategoryColor")]
+    partial class AddCategoryColor
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/api/api/Migrations/20250621153357_AddCategoryColor.cs
+++ b/src/api/api/Migrations/20250621153357_AddCategoryColor.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FinSync.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCategoryColor : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Color",
+                table: "Categories",
+                type: "nvarchar(11)",
+                maxLength: 11,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Color",
+                table: "Categories");
+        }
+    }
+}

--- a/src/api/api/Models/Category.cs
+++ b/src/api/api/Models/Category.cs
@@ -12,6 +12,11 @@ namespace FinSync.Models
         public int UserId { get; set; }
         public string CategoryName { get; set; }
 
+        // Stored as "R,G,B" (e.g. "255,0,0" for red)
+        [Required]
+        [MaxLength(11)] // "255,255,255" length
+        public string Color { get; set; }
+
         [ForeignKey(nameof(UserId))]
         public User User { get; set; }
 

--- a/src/api/api/Models/FinSyncContext.cs
+++ b/src/api/api/Models/FinSyncContext.cs
@@ -32,6 +32,11 @@ namespace FinSync.Data
                 .IsUnique();
 
             modelBuilder.Entity<Category>()
+                .Property(c => c.Color)
+                .IsRequired()
+                .HasMaxLength(11);
+
+            modelBuilder.Entity<Category>()
                 .HasOne(c => c.User)
                 .WithMany()
                 .HasForeignKey(c => c.UserId)


### PR DESCRIPTION
## Summary
- add a `Color` string property to `Category`
- map the new `Color` field in `CategoryDto` and `CategoryController`
- configure EF model to require and limit `Color`
- create migration `AddCategoryColor`

## Testing
- `dotnet build src/api/finSync.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6856cffb0cec832ea86e1c27845f5c3a