### PR TITLE
Add health checks and secure admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Both projects are included in this repository along with a small helper for clea
 - JWT-based authentication with API key header
 - Budget, income and expense management screens
 - LiveCharts visualizations
-- Simple console panel for monitoring the API
+- Interactive console panel with admin mode for viewing statistics
 
 ## Prerequisites
 
@@ -39,6 +39,8 @@ dotnet run
 ```
 
 The API listens by default on `http://localhost:5034` and requires a header `x-api-key` with value `12345-abcdef-67890`.
+
+Health information is exposed at `/healthz` (machine readable) and `/health` (detailed). The console admin panel is protected by a password defined in `appsettings.json` under `AdminPanel:Password`.
 
 ## Running the Client
 

--- a/src/api/api/Controllers/HealthController.cs
+++ b/src/api/api/Controllers/HealthController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace FinSync.Controllers;
 
@@ -7,7 +8,23 @@ namespace FinSync.Controllers;
 [Route("health")]
 public class HealthController : ControllerBase
 {
+    private readonly HealthCheckService _healthService;
+
+    public HealthController(HealthCheckService healthService)
+    {
+        _healthService = healthService;
+    }
+
     [HttpGet]
     [AllowAnonymous]
-    public IActionResult Get() => Ok(new { status = "healthy" });
+    public async Task<IActionResult> Get()
+    {
+        var report = await _healthService.CheckHealthAsync();
+        var details = report.Entries.ToDictionary(e => e.Key, e => e.Value.Status.ToString());
+        return Ok(new
+        {
+            status = report.Status.ToString(),
+            details
+        });
+    }
 }

--- a/src/api/api/Panel/Panel.cs
+++ b/src/api/api/Panel/Panel.cs
@@ -1,13 +1,24 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using FinSync.Data;
+using Quartz;
+using System.Linq;
 
 namespace FinSync.Panel
 {
     public static class ConsolePanel
     {
-        public static void Start()
+        private static IServiceProvider _services;
+        private static string _adminPassword = "admin";
+
+        public static void Start(IServiceProvider services, IConfiguration config)
         {
+            _services = services;
+            _adminPassword = config["AdminPanel:Password"] ?? _adminPassword;
             Task.Run(() => RunMenu());
         }
 
@@ -90,13 +101,57 @@ namespace FinSync.Panel
 
         private static void ShowAdminPanel()
         {
-            centerBlock(new[]
+            Console.Write("Admin password: ");
+            string entered = ReadPassword();
+            if (entered != _adminPassword)
+            {
+                centerBlock(new[] { "Invalid password." });
+                return;
+            }
+
+            using var scope = _services.CreateScope();
+            var ctx = scope.ServiceProvider.GetRequiredService<FinSyncContext>();
+            var schedulerFactory = scope.ServiceProvider.GetRequiredService<ISchedulerFactory>();
+            var scheduler = schedulerFactory.GetScheduler().Result;
+            var triggers = scheduler.GetTriggersOfJob(new JobKey("RecurringIncomeJob")).Result;
+            var nextRun = triggers.FirstOrDefault()?.GetNextFireTimeUtc()?.ToLocalTime();
+
+            var lines = new[]
             {
                 "🛠️ Admin Panel:",
-                "- Alerts count: TODO",
-                "- Jobs running: TODO",
-                "- Users online: TODO"
-            });
+                $"- Users: {ctx.Users.Count()}",
+                $"- Expenses: {ctx.Expenses.Count()}",
+                $"- Incomes: {ctx.Incomes.Count()}",
+                $"- Budgets: {ctx.Budgets.Count()}",
+                $"- Active Schedules: {ctx.RecurringIncomeSchedules.Count(r => r.IsActive)}",
+                $"- Next RecurringIncomeJob: {nextRun}"
+            };
+
+            centerBlock(lines);
+        }
+
+        private static string ReadPassword()
+        {
+            var sb = new StringBuilder();
+            ConsoleKeyInfo key;
+            while ((key = Console.ReadKey(true)).Key != ConsoleKey.Enter)
+            {
+                if (key.Key == ConsoleKey.Backspace)
+                {
+                    if (sb.Length > 0)
+                    {
+                        sb.Length--;
+                        Console.Write("\b \b");
+                    }
+                }
+                else if (!char.IsControl(key.KeyChar))
+                {
+                    sb.Append(key.KeyChar);
+                    Console.Write("*");
+                }
+            }
+            Console.WriteLine();
+            return sb.ToString();
         }
 
         private static void StopAPI()

--- a/src/api/api/Program.cs
+++ b/src/api/api/Program.cs
@@ -10,6 +10,7 @@ using FinSync.Data;
 using Quartz;
 using Quartz.Spi;
 using FinSync.Panel;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -27,6 +28,10 @@ var validApiKeys = builder.Configuration.GetSection("ApiKeySettings:ValidKeys").
 // ✅ Database Context
 builder.Services.AddDbContext<FinSyncContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+// ✅ Health Checks
+builder.Services.AddHealthChecks()
+    .AddDbContextCheck<FinSyncContext>(name: "Database");
 
 // ✅ Authentication (JWT)
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
@@ -94,7 +99,7 @@ builder.Services.AddSingleton(apiKeyHeader ?? "x-api-key");
 var app = builder.Build();
 
 // ✅ API panel
-ConsolePanel.Start();
+ConsolePanel.Start(app.Services, app.Configuration);
 
 // ✅ Middleware
 app.UseSerilogRequestLogging();
@@ -131,6 +136,7 @@ app.Use(async (context, next) =>
     await next();
 });
 
+app.MapHealthChecks("/healthz");
 app.MapControllers();
 
 app.Run();

--- a/src/api/api/appsettings.json
+++ b/src/api/api/appsettings.json
@@ -15,6 +15,10 @@
     "HeaderName": "x-api-key"
   },
 
+  "AdminPanel": {
+    "Password": "admin"
+  },
+
   "IpRateLimiting": {
     "EnableEndpointRateLimiting": true,
     "StackBlockedRequests": false,


### PR DESCRIPTION
## Summary
- implement database-backed health checks
- expose health check endpoint and improved health controller
- secure and enrich console admin panel
- pass service provider/config to console panel
- document admin password & health endpoints

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685746e890d0832ea3cced8095b6979e