### PR TITLE
Implement AI overview in client

### DIFF
--- a/src/Client/login/Client.csproj
+++ b/src/Client/login/Client.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Helpers\Tasks.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="Helpers\AiHelper.cs" />
     <Compile Include="MainForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/Client/login/Helpers/AiHelper.cs
+++ b/src/Client/login/Helpers/AiHelper.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace login.Helpers
+{
+    internal static class AiHelper
+    {
+        private const string ApiUrl = "https://api.openai.com/v1/chat/completions";
+        private const string KeyFile = "openai.key";
+
+        private static string? GetApiKey()
+        {
+            var envKey = Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+            if (!string.IsNullOrWhiteSpace(envKey))
+                return envKey.Trim();
+
+            if (File.Exists(KeyFile))
+                return File.ReadAllText(KeyFile).Trim();
+
+            return null;
+        }
+
+        public static async Task<string> GenerateOverviewAsync(decimal income, decimal expenses)
+        {
+            var apiKey = GetApiKey();
+            if (string.IsNullOrEmpty(apiKey))
+                return "AI summary unavailable: missing API key.";
+
+            using var client = new HttpClient();
+            client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+
+            var prompt = $"Provide a short financial overview. Monthly income: {income:C2}. Monthly expenses: {expenses:C2}.";
+
+            var request = new
+            {
+                model = "gpt-3.5-turbo",
+                messages = new[]
+                {
+                    new { role = "system", content = "You are a helpful finance assistant." },
+                    new { role = "user", content = prompt }
+                },
+                max_tokens = 100,
+                temperature = 0.7
+            };
+
+            var json = JsonSerializer.Serialize(request);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            try
+            {
+                var response = await client.PostAsync(ApiUrl, content);
+                var body = await response.Content.ReadAsStringAsync();
+                if (!response.IsSuccessStatusCode)
+                {
+                    return $"AI request failed: {response.StatusCode}";
+                }
+
+                using var doc = JsonDocument.Parse(body);
+                var msg = doc.RootElement.GetProperty("choices")[0].GetProperty("message").GetProperty("content").GetString();
+                return msg?.Trim() ?? "AI response empty.";
+            }
+            catch (Exception ex)
+            {
+                return "AI request failed: " + ex.Message;
+            }
+        }
+    }
+}

--- a/src/Client/login/Tabs/Overview.Designer.cs
+++ b/src/Client/login/Tabs/Overview.Designer.cs
@@ -39,6 +39,7 @@
             this.label5 = new System.Windows.Forms.Label();
             this.ExpensesPanel = new Guna.UI2.WinForms.Guna2Panel();
             this.closeapp = new Guna.UI2.WinForms.Guna2ControlBox();
+            this.aiButton = new Guna.UI2.WinForms.Guna2Button();
             this.guna2GradientPanel1.SuspendLayout();
             this.guna2GradientPanel2.SuspendLayout();
             this.SuspendLayout();
@@ -148,6 +149,25 @@
             this.ChartPanel.ShadowDecoration.Parent = this.ChartPanel;
             this.ChartPanel.Size = new System.Drawing.Size(360, 465);
             this.ChartPanel.TabIndex = 14;
+            //
+            // aiButton
+            //
+            this.aiButton.Animated = true;
+            this.aiButton.BackColor = System.Drawing.Color.Transparent;
+            this.aiButton.BorderRadius = 5;
+            this.aiButton.CheckedState.Parent = this.aiButton;
+            this.aiButton.CustomImages.Parent = this.aiButton;
+            this.aiButton.FillColor = System.Drawing.Color.FromArgb(27, 43, 48);
+            this.aiButton.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.aiButton.ForeColor = System.Drawing.Color.White;
+            this.aiButton.Location = new System.Drawing.Point(30, 560);
+            this.aiButton.Name = "aiButton";
+            this.aiButton.ShadowDecoration.Parent = this.aiButton;
+            this.aiButton.Size = new System.Drawing.Size(150, 30);
+            this.aiButton.TabIndex = 19;
+            this.aiButton.Text = "AI Overview";
+            this.aiButton.UseTransparentBackground = true;
+            this.aiButton.Click += new System.EventHandler(this.aiButton_Click);
             // 
             // label5
             // 
@@ -199,6 +219,7 @@
             this.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(18)))), ((int)(((byte)(20)))), ((int)(((byte)(20)))));
             this.ClientSize = new System.Drawing.Size(884, 561);
             this.Controls.Add(this.closeapp);
+            this.Controls.Add(this.aiButton);
             this.Controls.Add(this.label5);
             this.Controls.Add(this.ChartPanel);
             this.Controls.Add(this.ExpensesPanel);
@@ -229,5 +250,6 @@
         private System.Windows.Forms.Label label5;
         private Guna.UI2.WinForms.Guna2Panel ExpensesPanel;
         private Guna.UI2.WinForms.Guna2ControlBox closeapp;
+        private Guna.UI2.WinForms.Guna2Button aiButton;
     }
 }

--- a/src/Client/login/Tabs/Overview.cs
+++ b/src/Client/login/Tabs/Overview.cs
@@ -10,12 +10,19 @@ using LiveCharts.WinForms;
 using login.Helpers;
 using login.Tabs;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 
 namespace login.Tabs
 {
     public partial class Overview : Form
     {
         private readonly HttpClient _http;
+        private class MonthlyBalance
+        {
+            public decimal Income { get; set; }
+            public decimal Expenses { get; set; }
+            public decimal Available { get; set; }
+        }
         public Overview(HttpClient httpClient)
         {
             InitializeComponent();
@@ -31,6 +38,7 @@ namespace login.Tabs
         private async void Loader()
         {
             var balance = await GetBalanceAsync();
+            var monthly = await GetMonthlyBalanceAsync();
             Charts chartHelper = new Charts();
             CartesianChart ovChart = chartHelper.SetupChart();
 
@@ -43,6 +51,10 @@ namespace login.Tabs
             expList.FormBorderStyle = FormBorderStyle.None;
 
             BalanceTxt.Text = $"{balance:C2}";
+            if (monthly != null)
+            {
+                lblSpent.Text = $"{monthly.Expenses:C2}";
+            }
             this.ExpensesPanel.Controls.Add(expList);
             expList.Show();
             //this.ChartPanel.Controls.Add(ovChart); // Chart added to ChartPanel
@@ -85,6 +97,26 @@ namespace login.Tabs
             }
         }
 
+        private async Task<MonthlyBalance?> GetMonthlyBalanceAsync()
+        {
+            try
+            {
+                var response = await _http.GetAsync("api/balance/monthly");
+                if (!response.IsSuccessStatusCode)
+                    return null;
+
+                var json = await response.Content.ReadAsStringAsync();
+                return JsonSerializer.Deserialize<MonthlyBalance>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         private void label4_Click(object sender, EventArgs e)
         {
 
@@ -103,6 +135,19 @@ namespace login.Tabs
         private void closeapp_Click(object sender, EventArgs e)
         {
             Application.Exit();
+        }
+
+        private async void aiButton_Click(object sender, EventArgs e)
+        {
+            var monthly = await GetMonthlyBalanceAsync();
+            if (monthly == null)
+            {
+                MessageBox.Show("Unable to fetch monthly balance.");
+                return;
+            }
+
+            var summary = await AiHelper.GenerateOverviewAsync(monthly.Income, monthly.Expenses);
+            MessageBox.Show(summary, "AI Overview");
         }
     }
 }


### PR DESCRIPTION
## Summary
- add `AiHelper` to request a brief summary from OpenAI
- include new button in overview form for AI summary
- display monthly expenses in overview screen
- wire up AI call on button click

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857fcb328dc832e8e294fe3e0a5ffcc