### PR TITLE
Add admin user management console

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Both projects are included in this repository along with a small helper for clea
 - JWT-based authentication with API key header
 - Budget, income and expense management screens
 - LiveCharts visualizations
-- Interactive console panel with admin mode for viewing statistics
+ - Interactive console panel with admin mode for viewing statistics and user management
+ - Admin REST endpoints secured by JWT role claims
 
 ## Prerequisites
 
@@ -40,7 +41,9 @@ dotnet run
 
 The API listens by default on `http://localhost:5034` and requires a header `x-api-key` with value `12345-abcdef-67890`.
 
-Health information is exposed at `/healthz` (machine readable) and `/health` (detailed). The console admin panel is protected by a password defined in `appsettings.json` under `AdminPanel:Password`.
+Health information is exposed at `/healthz` (machine readable) and `/health` (detailed). The console admin panel now authenticates using an admin user account (role `admin`) stored in the database and lets admins list and promote users.
+
+Admin-only endpoints are available under `/api/admin` and require a JWT for a user with the `admin` role.
 
 ## Running the Client
 

--- a/src/api/api/Controllers/AdminController.cs
+++ b/src/api/api/Controllers/AdminController.cs
@@ -1,0 +1,39 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using FinSync.Data;
+using FinSync.Models;
+using System.Linq;
+
+namespace FinSync.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(Roles = "admin")]
+public class AdminController : ControllerBase
+{
+    private readonly FinSyncContext _context;
+
+    public AdminController(FinSyncContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet("users")]
+    public IActionResult GetUsers()
+    {
+        var users = _context.Users.Select(u => new { u.UserId, u.Username, u.Role }).ToList();
+        return Ok(users);
+    }
+
+    [HttpPost("promote/{id}")]
+    public IActionResult Promote(int id)
+    {
+        var user = _context.Users.FirstOrDefault(u => u.UserId == id);
+        if (user == null)
+            return NotFound();
+
+        user.Role = "admin";
+        _context.SaveChanges();
+        return NoContent();
+    }
+}

--- a/src/api/api/Controllers/AuthController.cs
+++ b/src/api/api/Controllers/AuthController.cs
@@ -68,7 +68,8 @@ public class AuthController : ControllerBase
         var claims = new[]
         {
             new Claim(JwtRegisteredClaimNames.Sub, user.Username),
-            new Claim("userId", user.UserId.ToString())
+            new Claim("userId", user.UserId.ToString()),
+            new Claim(ClaimTypes.Role, user.Role)
         };
 
         var token = new JwtSecurityToken(

--- a/src/api/api/Panel/Panel.cs
+++ b/src/api/api/Panel/Panel.cs
@@ -3,8 +3,8 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Configuration;
 using FinSync.Data;
+using FinSync.Utils;
 using Quartz;
 using System.Linq;
 
@@ -13,12 +13,10 @@ namespace FinSync.Panel
     public static class ConsolePanel
     {
         private static IServiceProvider _services;
-        private static string _adminPassword = "admin";
 
-        public static void Start(IServiceProvider services, IConfiguration config)
+        public static void Start(IServiceProvider services)
         {
             _services = services;
-            _adminPassword = config["AdminPanel:Password"] ?? _adminPassword;
             Task.Run(() => RunMenu());
         }
 
@@ -101,24 +99,73 @@ namespace FinSync.Panel
 
         private static void ShowAdminPanel()
         {
+            Console.Write("Admin username: ");
+            string user = Console.ReadLine()?.Trim() ?? string.Empty;
             Console.Write("Admin password: ");
-            string entered = ReadPassword();
-            if (entered != _adminPassword)
-            {
-                centerBlock(new[] { "Invalid password." });
-                return;
-            }
+            string pass = ReadPassword();
 
             using var scope = _services.CreateScope();
             var ctx = scope.ServiceProvider.GetRequiredService<FinSyncContext>();
-            var schedulerFactory = scope.ServiceProvider.GetRequiredService<ISchedulerFactory>();
-            var scheduler = schedulerFactory.GetScheduler().Result;
+            var admin = ctx.Users.FirstOrDefault(u => u.Username == user && u.Role == "admin");
+            if (admin == null || !PasswordHelper.VerifyPassword(admin.PasswordHash, pass))
+            {
+                centerBlock(new[] { "Invalid credentials." });
+                return;
+            }
+
+            var schedFactory = scope.ServiceProvider.GetRequiredService<ISchedulerFactory>();
+            AdminMenu(ctx, schedFactory);
+        }
+
+        private static void AdminMenu(FinSyncContext ctx, ISchedulerFactory schedFactory)
+        {
+            while (true)
+            {
+                Console.Clear();
+                var options = new[]
+                {
+                    "1 -> View statistics",
+                    "2 -> List users",
+                    "3 -> Promote user",
+                    "4 -> Back"
+                };
+                centerBlock(options);
+
+                var key = Console.ReadKey(true).Key;
+                Console.Clear();
+
+                switch (key)
+                {
+                    case ConsoleKey.D1:
+                        ShowStats(ctx, schedFactory);
+                        break;
+                    case ConsoleKey.D2:
+                        ListUsers(ctx);
+                        break;
+                    case ConsoleKey.D3:
+                        PromoteUser(ctx);
+                        break;
+                    case ConsoleKey.D4:
+                        return;
+                    default:
+                        centerBlock(new[] { "Invalid option." });
+                        break;
+                }
+
+                centerBlock(new[] { "\nPress any key to continue..." });
+                Console.ReadKey(true);
+            }
+        }
+
+        private static void ShowStats(FinSyncContext ctx, ISchedulerFactory schedFactory)
+        {
+            var scheduler = schedFactory.GetScheduler().Result;
             var triggers = scheduler.GetTriggersOfJob(new JobKey("RecurringIncomeJob")).Result;
             var nextRun = triggers.FirstOrDefault()?.GetNextFireTimeUtc()?.ToLocalTime();
 
             var lines = new[]
             {
-                "🛠️ Admin Panel:",
+                "🛠️ Statistics:",
                 $"- Users: {ctx.Users.Count()}",
                 $"- Expenses: {ctx.Expenses.Count()}",
                 $"- Incomes: {ctx.Incomes.Count()}",
@@ -128,6 +175,42 @@ namespace FinSync.Panel
             };
 
             centerBlock(lines);
+        }
+
+        private static void ListUsers(FinSyncContext ctx)
+        {
+            var users = ctx.Users
+                .Select(u => $"{u.UserId}: {u.Username} ({u.Role})")
+                .ToArray();
+
+            if (users.Length == 0)
+            {
+                centerBlock(new[] { "No users found." });
+                return;
+            }
+
+            centerBlock(users);
+        }
+
+        private static void PromoteUser(FinSyncContext ctx)
+        {
+            Console.Write("Enter user ID to promote: ");
+            if (!int.TryParse(Console.ReadLine(), out var id))
+            {
+                centerBlock(new[] { "Invalid ID." });
+                return;
+            }
+
+            var user = ctx.Users.FirstOrDefault(u => u.UserId == id);
+            if (user == null)
+            {
+                centerBlock(new[] { "User not found." });
+                return;
+            }
+
+            user.Role = "admin";
+            ctx.SaveChanges();
+            centerBlock(new[] { "User promoted to admin." });
         }
 
         private static string ReadPassword()

--- a/src/api/api/Program.cs
+++ b/src/api/api/Program.cs
@@ -100,7 +100,7 @@ builder.Services.AddSingleton(apiKeyHeader ?? "x-api-key");
 var app = builder.Build();
 
 // ✅ API panel
-ConsolePanel.Start(app.Services, app.Configuration);
+ConsolePanel.Start(app.Services);
 
 // ✅ Middleware
 app.UseSerilogRequestLogging();


### PR DESCRIPTION
## Summary
- extend the interactive console panel with an admin menu
- allow admins to view statistics, list users and promote them
- document expanded admin panel abilities in README

## Testing
- `dotnet build -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6857f8f5b8b4832ea837267a77382440