### PR TITLE
Add default goal category and track goal spending

### DIFF
--- a/src/api/api/Controllers/AuthController.cs
+++ b/src/api/api/Controllers/AuthController.cs
@@ -47,10 +47,21 @@ public class AuthController : ControllerBase
             PasswordHash = PasswordHelper.HashPassword(request.Password),
             Role = "user"
         };
-    
+
         _context.Users.Add(newUser);
         _context.SaveChanges();
-    
+
+        // Create default "goal" category for the new user
+        var goalCategory = new Category
+        {
+            UserId = newUser.UserId,
+            CategoryName = "goal",
+            Color = "0,128,0"
+        };
+
+        _context.Categories.Add(goalCategory);
+        _context.SaveChanges();
+
         var user = _context.Users.FirstOrDefault(u => u.Username == request.Username);
         var token = GenerateJwtToken(user);
         return Ok(new

--- a/src/api/api/Controllers/GoalController.cs
+++ b/src/api/api/Controllers/GoalController.cs
@@ -70,11 +70,38 @@ namespace FinSync.Controllers
             var goal = await _context.Goals.FirstOrDefaultAsync(g => g.GoalId == id && g.UserId == userId.Value);
             if (goal == null) return NotFound();
 
-            goal.CurrentSaved += dto.Amount;
-            if (goal.CurrentSaved > goal.TargetAmount)
-                goal.CurrentSaved = goal.TargetAmount;
+            var amountAllowed = Math.Min(dto.Amount, goal.TargetAmount - goal.CurrentSaved);
+            if (amountAllowed <= 0)
+                return BadRequest("Goal already reached.");
 
+            goal.CurrentSaved += amountAllowed;
+
+            // Ensure user has a "goal" category
+            var goalCategory = await _context.Categories.FirstOrDefaultAsync(c => c.UserId == userId.Value && c.CategoryName == "goal");
+            if (goalCategory == null)
+            {
+                goalCategory = new Category
+                {
+                    UserId = userId.Value,
+                    CategoryName = "goal",
+                    Color = "0,128,0"
+                };
+                _context.Categories.Add(goalCategory);
+                await _context.SaveChangesAsync();
+            }
+
+            var expense = new Expense
+            {
+                UserId = userId.Value,
+                Amount = amountAllowed,
+                Description = $"Goal: {goal.Name}",
+                Date = DateTime.UtcNow,
+                CategoryId = goalCategory.CategoryId
+            };
+
+            _context.Expenses.Add(expense);
             await _context.SaveChangesAsync();
+
             return Ok(new { message = "Goal progress updated.", currentSaved = goal.CurrentSaved });
         }
 


### PR DESCRIPTION
## Summary
- create a goal category for new users when they register
- when adding money to a goal, also record an expense under the goal category

## Testing
- `dotnet build -v q`

------
https://chatgpt.com/codex/tasks/task_e_685bcf0de348832e97ed33de68a4e377