### PR TITLE
Fix month filtering for incomes and expenses

### DIFF
--- a/src/Client/login/Tabs/Expenses.cs
+++ b/src/Client/login/Tabs/Expenses.cs
@@ -138,7 +138,7 @@ namespace login.Tabs
         {
             _categories = await CategoriesList.GetCategoriesAsync(_http);
 
-            var resp = await _http.GetAsync("api/expense/summary");
+            var resp = await _http.GetAsync("api/expense");
             if (!resp.IsSuccessStatusCode)
             {
                 MessageBox.Show($"Failed loading expenses: {resp.StatusCode}");
@@ -147,8 +147,7 @@ namespace login.Tabs
 
             var json = await resp.Content.ReadAsStringAsync();
             var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var wrapper = JsonSerializer.Deserialize<ExpenseResponse>(json, opts);
-            _rawExpenses = wrapper?.Expenses ?? new List<Expense>();
+            _rawExpenses = JsonSerializer.Deserialize<List<Expense>>(json, opts) ?? new List<Expense>();
 
             SetupCategories();
             RefreshList();

--- a/src/Client/login/Tabs/Incomes.cs
+++ b/src/Client/login/Tabs/Incomes.cs
@@ -138,7 +138,7 @@ namespace login.Tabs
         private async Task LoadIncomes()
         {
             _categories = await CategoriesList.GetCategoriesAsync(_http);
-            var resp = await _http.GetAsync("api/income/summary");
+            var resp = await _http.GetAsync("api/income");
             if (!resp.IsSuccessStatusCode)
             {
                 MessageBox.Show($"Failed loading incomes: {resp.StatusCode}");
@@ -146,8 +146,7 @@ namespace login.Tabs
             }
             var json = await resp.Content.ReadAsStringAsync();
             var opts = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-            var wrapper = JsonSerializer.Deserialize<IncomeResponse>(json, opts);
-            _rawIncomes = wrapper?.Incomes ?? new List<Income>();
+            _rawIncomes = JsonSerializer.Deserialize<List<Income>>(json, opts) ?? new List<Income>();
 
             SetupCategories();
             RefreshList();


### PR DESCRIPTION
## Summary
- retrieve full expense/income lists instead of monthly summaries

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c36e324c0832eb9f5e01f75089579